### PR TITLE
Update UKFTractography hash to fix static build with newer UKF

### DIFF
--- a/pnlpipe_pipelines/_pnl.py
+++ b/pnlpipe_pipelines/_pnl.py
@@ -19,7 +19,7 @@ bet_threshold = 0.1
 BRAINSTools_hash = '95ac1e287c'
 trainingDataT1AHCC_hash = 'd6e5990'
 FreeSurfer_version = '5.3.0'
-UKFTractography_hash = '64efcbb7'
+UKFTractography_hash = 'ce12942bd'
 tract_querier_hash = 'c57d670'
 ukfparams = ["--Ql", 70, "--Qm", 0.001, "--Rs", 0.015, "--numTensor", 2,
              "--recordLength", 1.7, "--seedFALimit", 0.18, "--seedsPerVoxel",

--- a/pnlpipe_software/UKFTractography.py
+++ b/pnlpipe_software/UKFTractography.py
@@ -4,7 +4,7 @@ from plumbum import local, FG
 from plumbum.cmd import cmake
 import logging
 
-DEFAULT_HASH = '35ca38d'
+DEFAULT_HASH = 'ce12942bd'
 
 def make(commit=DEFAULT_HASH):
 


### PR DESCRIPTION
Fixes the `libUKFBase.so: cannot open shared object file` error with up-to-date UKF, by bumping hash to this update:

https://github.com/pnlbwh/ukftractography/pull/107