### PR TITLE
ENH: Transition to Python 3.8

### DIFF
--- a/python_env/environment38.yml
+++ b/python_env/environment38.yml
@@ -4,23 +4,23 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.6
+  - python=3.8
   - ipython
   - pytest
   - plumbum
   - future
   - numpy
   - pandas
-  - vtk<=8.2.0
+  - vtk
   - cmake
   - nibabel
   - nilearn
-  - dipy<1.3.0
+  - dipy
   - pyyaml
   - psutil
   - csvkit
-  - gcc_linux-64<=7.3.0
-  - gxx_linux-64<=7.3.0
+  - gcc_linux-64
+  - gxx_linux-64
   - joblib
   - matplotlib
   - conda-build
@@ -28,10 +28,10 @@ dependencies:
   - sqlalchemy
   - dash
   - statsmodels
-  - tensorflow==1.12.0
-  - keras==2.2.4
+  - tensorflow
+  - keras
   - scikit-image
-  - h5py<3
+  - h5py
   - git
   - pip
   - pip:

--- a/python_env/environment38_gpu.yml
+++ b/python_env/environment38_gpu.yml
@@ -7,11 +7,11 @@ dependencies:
     - python
     - ipython
 
-    - tensorflow-gpu==1.12.0
-    - cudnn==7.6.0
-    - keras==2.2.4
-    - torchvision=0.8.2
-    - h5py<3
+    - tensorflow-gpu
+    - cudnn
+    - keras
+    - torchvision
+    - h5py
 
     - nibabel
     - luigi
@@ -25,7 +25,7 @@ dependencies:
         - gputil
         - scikit-image
         - SimpleITK
-        - dipy==1.2.0
+        - dipy
         - torch
         - git+https://github.com/pnlbwh/conversion.git
         - git+https://github.com/MIC-DKFZ/batchgenerators#egg=batchgenerators

--- a/python_env/requirements.txt
+++ b/python_env/requirements.txt
@@ -1,6 +1,6 @@
 # This recipe is not maintained actively.
-# Please follow environment36.yml instead.
-# In fact, it is a mirror of environment36.yml
+# Please follow environment38.yml instead.
+# In fact, it is a mirror of environment38.yml
 # but not tested adequately as `pip install -r requirements.txt`.
 
 ipython
@@ -9,11 +9,11 @@ plumbum
 future
 numpy
 pandas
-vtk<=8.2.0
+vtk
 cmake
 nibabel
 nilearn
-dipy<1.3.0
+dipy
 pyyaml
 psutil
 csvkit
@@ -24,10 +24,10 @@ conda-build
 luigi
 sqlalchemy
 dash
-tensorflow==1.12.0
-keras==2.2.4
+tensorflow
+keras
 scikit-image
-h5py<3
+h5py
 git
 git+https://github.com/SlicerDMRI/whitematteranalysis.git
 git+https://github.com/dstrohl/Python_log_indenter.git


### PR DESCRIPTION
Transition to Python 3.8 as Python 3.6 is deprected since 2021-12-23, and Python 3.7 was also deprecated on 2023-06-27:
https://devguide.python.org/versions/#unsupported-versions